### PR TITLE
Daryl Haase Unit Test Training

### DIFF
--- a/Refactoring/Store.cs
+++ b/Refactoring/Store.cs
@@ -32,7 +32,7 @@ namespace Refactoring
                 throw new OutOfStockException();
             }
 
-            product.Quantity = product.Quantity - quantity+1;
+            product.Quantity = product.Quantity - quantity;
             user.Balance = user.Balance - product.Price * quantity;
 
             dataManager.SaveUser(user);

--- a/UnitTestProject/AuthenticatorTests.cs
+++ b/UnitTestProject/AuthenticatorTests.cs
@@ -1,0 +1,228 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using Refactoring;
+
+namespace UnitTestProject
+{
+    [TestFixture]
+    public class AuthenticatorTests
+    {
+        private Authenticator _AUTHENTICATOR;
+        private List<User> _USERS;
+
+        [Test]
+        public void Test_Authenticate_EmptyUserName()
+        {
+            //Act
+            User actual = _AUTHENTICATOR.Authenticate("", "");
+
+            //Assert
+            Assert.IsNull(actual);
+        }
+
+        [Test]
+        public void Test_Authenticate_NullUserName()
+        {
+            //Act
+            User actual = _AUTHENTICATOR.Authenticate(null, null);
+
+            //Assert
+            Assert.IsNull(actual);
+        }
+
+        [Test]
+        public void Test_Authenticate_InvalidUserName()
+        {
+            //Act
+            User actual = _AUTHENTICATOR.Authenticate("ThisIsNotAValidUser", "ThisIsNotAValidPassword");
+
+            //Assert
+            Assert.IsNull(actual);
+        }
+
+        [Test]
+        public void Test_Authenticate_InvalidPassword()
+        {
+            //Act
+            User actual = _AUTHENTICATOR.Authenticate(_USERS[0].Name, "ThisIsNotAValidPassword");
+
+            //Assert
+            Assert.IsNull(actual);
+        }
+
+        [Test]
+        public void Test_Authenticate_ValidUser()
+        {
+            //Arrange
+            User expected = _USERS[0];
+
+            //Act
+            User actual = _AUTHENTICATOR.Authenticate(_USERS[0].Name, _USERS[0].Password);
+
+            //Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void Test_Authenticate_AnotherUsersPassword()
+        {
+            User actual = _AUTHENTICATOR.Authenticate(_USERS[0].Name, _USERS[1].Password);
+
+            //Assert
+            Assert.IsNull(actual);
+        }
+
+        [Test]
+        public void Test_Authenticate_LastUser()
+        {
+            //Arrange
+            User expected = _USERS[_USERS.Count - 1];
+
+            User actual = _AUTHENTICATOR.Authenticate(_USERS[_USERS.Count - 1].Name, _USERS[_USERS.Count - 1].Password);
+
+            //Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void Test_Authenticate_TwoUsersWithSameName_FirstUser()
+        {
+            //Arrange
+            List<User> users = new List<User>();
+
+            User userA1 = new User();
+            userA1.Balance = 1000.00;
+            userA1.Name = "UserA";
+            userA1.Password = "PassA";
+
+            User userA2 = new User();
+            userA2.Balance = 1.00;
+            userA2.Name = "UserA";
+            userA2.Password = "PassB";
+
+            users.Add(userA1);
+            users.Add(userA2);
+
+            Authenticator authenicator = new Authenticator(users);
+
+            //Act
+            User actual = authenicator.Authenticate(userA1.Name, userA1.Password);
+
+            //Assert
+            Assert.AreSame(userA1, actual);
+        }
+
+        [Test]
+        public void Test_Authenticate_TwoUsersWithSameName_SecondUser()
+        {
+            //Arrange
+            List<User> users = new List<User>();
+
+            User userA1 = new User();
+            userA1.Balance = 1000.00;
+            userA1.Name = "UserA";
+            userA1.Password = "PassA";
+
+            User userA2 = new User();
+            userA2.Balance = 1.00;
+            userA2.Name = "UserA";
+            userA2.Password = "PassB";
+
+            users.Add(userA1);
+            users.Add(userA2);
+
+            Authenticator authenicator = new Authenticator(users);
+
+            //Act
+            User actual = authenicator.Authenticate(userA2.Name, userA2.Password);
+
+            //Assert
+            Assert.AreSame(userA2, actual);
+        }
+
+        [Test]
+        public void Test_Authenticate_TwoUsersWithSameNameAndPassword()
+        {
+            //Arrange
+            List<User> users = new List<User>();
+
+            User userA1 = new User();
+            userA1.Balance = 1000.00;
+            userA1.Name = "UserA";
+            userA1.Password = "PassA";
+
+            User userA2 = new User();
+            userA2.Balance = 1.00;
+            userA2.Name = "UserA";
+            userA2.Password = "PassA";
+
+            users.Add(userA1);
+            users.Add(userA2);
+
+            Authenticator authenicator = new Authenticator(users);
+
+            //Act
+            User actual = authenicator.Authenticate(userA2.Name, userA2.Password);
+
+            //Assert
+            Assert.IsNull(actual, "It should not be possible to have two users with the same name and password.");
+        }
+
+
+
+        [SetUp]
+        public void Test_Initialize()
+        {
+            _USERS = CreateUsers();
+            _AUTHENTICATOR = new Authenticator(_USERS);
+        }
+        
+        [TearDown]
+        public void Test_Cleanup()
+        {
+            _USERS = null;
+            _AUTHENTICATOR = null;
+        }
+
+        private List<User> CreateUsers()
+        {
+            List<User> users = new List<User>();
+
+            User userA = new User();
+            userA.Balance = 1.00;
+            userA.Name = "UserA";
+            userA.Password = "PassA";
+
+            User userB = new User();
+            userB.Balance = 10.00;
+            userB.Name = "UserB";
+            userB.Password = "PassB";
+
+            User userC = new User();
+            userC.Balance = 100.00;
+            userC.Name = "UserC";
+            userC.Password = "PassC";
+
+            User userD = new User();
+            userD.Balance = 0.00;
+            userD.Name = "UserD";
+            userD.Password = "PassD";
+
+            User userE = new User();
+            userE.Balance = -1.00;
+            userE.Name = "UserE";
+            userE.Password = "PassE";
+
+            users.Add(userA);
+            users.Add(userB);
+            users.Add(userC);
+            users.Add(userD);
+            users.Add(userE);
+
+            return users;
+        }
+    }
+}

--- a/UnitTestProject/IntegrationTests.cs
+++ b/UnitTestProject/IntegrationTests.cs
@@ -10,7 +10,7 @@ using System.Runtime.Serialization.Formatters.Binary;
 namespace UnitTestProject
 {
     [TestFixture]
-    //[Ignore("Disable integration tests")]
+    [Ignore("Disable integration tests")]
     public class IntegrationTests
     {
         private List<User> users;

--- a/UnitTestProject/StoreTests.cs
+++ b/UnitTestProject/StoreTests.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System.Runtime.Remoting;
+using Newtonsoft.Json;
 using NUnit.Framework;
 using Refactoring;
 using System;
@@ -13,6 +14,10 @@ namespace UnitTestProject
     [TestFixture]
     class StoreTests
     {
+        private const string DEFAULT_PRODUCT_ID = "1";
+        private const double DEFAULT_PRICE = 1.00;
+        private const int DEFAULT_QUANTITY = 1;
+
         private User createTestUser(string name, string password, double balance)
         {
             User testUser = new User();
@@ -34,23 +39,39 @@ namespace UnitTestProject
             return testProduct;
         }
 
+        private List<User> CreateUserWithBalance(string userName, double balance)
+        {
+            var users = new List<User>();
+            users.Add(createTestUser(userName, "", balance));
+
+            return users;
+        }
+
+        private List<Product> CreateDefaultProduct()
+        {
+            return CreateDefaultProduct(DEFAULT_PRICE, DEFAULT_QUANTITY);
+        }
+
+        private List<Product> CreateDefaultProduct(double price, int quantity)
+        {
+            var products = new List<Product>();
+            products.Add(createTestProduct(DEFAULT_PRODUCT_ID, "Product", price, quantity));
+
+            return products;
+        }
+
         [Test]
         public void Test_PurchaseThrowsNoErrorForValidFunds()
         {
             //Arrange
-            const string TEST_PRODUCT_ID = "1";
-
-            var users = new List<User>();
-            users.Add(createTestUser("Test User", "", 99.99));
-
-            var products = new List<Product>();
-            products.Add(createTestProduct(TEST_PRODUCT_ID, "Product", 9.99, 10));
+            var users = CreateUserWithBalance("Test User", 99.99);
+            var products = CreateDefaultProduct(9.99, 10);
 
             var dataManager = new DataManager(users, products);
             var store = new Store(users[0], dataManager);
 
             //Act
-            store.Purchase(TEST_PRODUCT_ID, 10);
+            store.Purchase(DEFAULT_PRODUCT_ID, 10);
 
             //Assert
             Assert.Pass("No assertion really necessary here");
@@ -60,35 +81,217 @@ namespace UnitTestProject
         public void Test_PurchaseRemovesProductFromStore()
         {
             //Arrange
+            var users = CreateUserWithBalance("Test User", 9999.99);
+            var products = CreateDefaultProduct(1.00, 10);
+
+            var dataManager = new DataManager(users, products);
+            var store = new Store(users[0], dataManager);
+
 
             //Act
+            store.Purchase(DEFAULT_PRODUCT_ID, 9);
 
             //Assert 
             //(choose the appropriate statement(s))
-            //Assert.AreEqual(1, products[0].Quantity);
+            Assert.AreEqual(1, products[0].Quantity);
             //Assert.AreSame(1, products[0].Quantity);
-            //Assert.IsTrue(products[0].Quantity == 1);
+            Assert.IsTrue(products[0].Quantity == 1);
         }
 
         [Test]
         public void Test_PurchaseThrowsExceptionWhenBalanceIsTooLow()
         {
             //Arrange
+            var users = CreateUserWithBalance("Test User", 1.00);
+            var products = CreateDefaultProduct(1.01, 10);
 
-            //Act
-
-            //Assert
+            var dataManager = new DataManager(users, products);
+            var store = new Store(users[0], dataManager);
+            
+            //Act & Assert
+            try
+            {
+                store.Purchase(DEFAULT_PRODUCT_ID, 1);
+                Assert.Fail();
+            }
+            catch (Exception e)
+            {
+                Assert.IsTrue(e is InsufficientFundsException);
+            }
         }
 
         [Test]
+        [ExpectedException(typeof(InsufficientFundsException))]
         public void Test_PurchaseThrowsExceptionWhenBalanceIsTooLowVersion2()
         {
             //Arrange
+            var users = CreateUserWithBalance("Test User", 1.00);
+            var products = CreateDefaultProduct(1.01, 10);
+
+            var dataManager = new DataManager(users, products);
+            var store = new Store(users[0], dataManager);
 
             //Act
+            store.Purchase(DEFAULT_PRODUCT_ID, 1);
 
             //Assert
+            Assert.Fail("Expected InsufficientFundsException");
         }
+
+        [Test]
+        [ExpectedException(typeof(OutOfStockException))]
+        public void Test_PurchaseThrowsExceptionWhenItemOutOfStock()
+        {
+            //Arrange
+            var users = CreateUserWithBalance("Test User", 100.00);
+            var products = CreateDefaultProduct();
+
+            var dataManager = new DataManager(users, products);
+            var store = new Store(users[0], dataManager);
+
+            //Act
+            store.Purchase(DEFAULT_PRODUCT_ID, 2);
+
+            //Assert
+            Assert.Fail("Expected OutOfStockException");
+        }
+
+        [Test]
+        public void Test_GetProductList()
+        {
+            //Arrange
+            string actualResult = "";
+            var users = CreateUserWithBalance("Test User", 100.00);
+            var products = CreateDefaultProduct();
+
+            var dataManager = new DataManager(users, products);
+            var store = new Store(users[0], dataManager);
+
+            //Act
+            actualResult = store.GetProductList();
+
+            //Assert
+            Assert.IsTrue(actualResult.Contains(products[0].Name));
+        }
+
+        [Test]
+        public void Test_GetProductList_NoProducts()
+        {
+            //Arrange
+            var users = CreateUserWithBalance("Test User", 100.00);
+            var products = new List<Product>();
+
+            var dataManager = new DataManager(users, products);
+            var store = new Store(users[0], dataManager);
+
+            //Act
+            store.GetProductList();
+
+            //Assert
+            Assert.Pass("GetProductList() successfully handled an empty list.");
+        }
+
+        [Test]
+        public void Test_NumberOfProducts()
+        {
+            //Arrange
+            const string TEST_PRODUCT_ID = "1";
+            const int NUM_OF_PRODUCTS = 4;
+            int actualNumberOfProducts;
+
+            var users = CreateUserWithBalance("Test User", 100.00);
+
+            var products = new List<Product>();
+            for (int i=0; i<NUM_OF_PRODUCTS; i++)
+                products.Add(createTestProduct(TEST_PRODUCT_ID+i, String.Format("Product({0})",i+1), 1.00, 1));
+
+            var dataManager = new DataManager(users, products);
+            var store = new Store(users[0], dataManager);
+
+            //Act
+            actualNumberOfProducts = store.NumberOfProducts();
+
+            //Assert
+            Assert.AreEqual(NUM_OF_PRODUCTS, actualNumberOfProducts);
+        }
+
+        [Test]
+        public void Test_NumberOfProducts_NoProducts()
+        {
+            //Arrange
+            int actualNumberOfProducts;
+            var users = CreateUserWithBalance("Test User", 100.00);
+            var products = new List<Product>();
+
+            var dataManager = new DataManager(users, products);
+            var store = new Store(users[0], dataManager);
+
+            //Act
+            actualNumberOfProducts = store.NumberOfProducts();
+
+            //Assert
+            Assert.AreEqual(0, actualNumberOfProducts);
+        }
+
+        [Test]
+        public void Test_ContainsProduct_ContainsProduct()
+        {
+            //Arrange
+            bool actualResult;
+            bool expectedResult = true;
+            var users = CreateUserWithBalance("Test User", 100.00);
+            var products = CreateDefaultProduct();
+
+            var dataManager = new DataManager(users, products);
+            var store = new Store(users[0], dataManager);
+
+            //Act
+            actualResult = store.ContainsProduct(DEFAULT_PRODUCT_ID);
+
+            //Assert
+            Assert.AreEqual(expectedResult, actualResult);
+        }
+
+        [Test]
+        public void Test_ContainsProduct_DoesNotContainsProduct()
+        {
+            //Arrange
+            bool actualResult;
+            bool expectedResult = false;
+            const string NONEXISTENT_PRODUCT_ID = "2";
+            var users = CreateUserWithBalance("Test User", 100.00);
+            var products = CreateDefaultProduct();
+
+            var dataManager = new DataManager(users, products);
+            var store = new Store(users[0], dataManager);
+
+            //Act
+            actualResult = store.ContainsProduct(NONEXISTENT_PRODUCT_ID);
+
+            //Assert
+            Assert.AreEqual(expectedResult, actualResult);
+        }
+
+        [Test]
+        public void Test_ContainsProduct_NoProductsInStore()
+        {
+            //Arrange
+            bool actualResult;
+            bool expectedResult = false;
+            var users = CreateUserWithBalance("Test User", 100.00);
+            var products = new List<Product>();
+
+            var dataManager = new DataManager(users, products);
+            var store = new Store(users[0], dataManager);
+
+            //Act
+            actualResult = store.ContainsProduct(DEFAULT_PRODUCT_ID);
+
+            //Assert
+            Assert.AreEqual(expectedResult, actualResult);
+        }
+
+
 
 
         // THE BELOW CODE IS REQUIRED TO PREVENT THE TESTS FROM MODIFYING THE USERS/PRODUCTS ON FILE

--- a/UnitTestProject/UnitTestProject.csproj
+++ b/UnitTestProject/UnitTestProject.csproj
@@ -35,6 +35,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
@@ -73,6 +74,7 @@
     <Compile Include="StoreTests.cs" />
     <Compile Include="IntegrationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="AuthenticatorTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Refactoring\Tusc.csproj">


### PR DESCRIPTION
Please refer to AuthenticatorTests::Test_Authenticate_TwoUsersWithSameNameAndPassword

It should not be possible to add two users with the same name and password. Because the lambda expression returns FirstOfDefault the balance of the first user will always be returned. In this test I created two users with identical names and passwords. The first has a balance of $1000 the second a balance of $1. If the second user were to try and log in, they would see a balance of $1000. Construct should not permit this scenario.
